### PR TITLE
fix: fix the linebreak warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,10 +23,6 @@
   ],
   "rules": {
     "react-refresh/only-export-components": "warn",
-    "linebreak-style": [
-      "error",
-      "unix"
-    ],
     "quotes": [
       "warn",
       "single"


### PR DESCRIPTION
Borré una regla de linter porque daba muchos warnings.